### PR TITLE
(Close #44) 存在しない CSS ファイルへの参照を削除

### DIFF
--- a/app/templates/app/opening.html
+++ b/app/templates/app/opening.html
@@ -1,9 +1,4 @@
 {% extends "app/base.html" %}
-{% load static %}
-
-{% block stylesheets %}
-  <link rel="stylesheet" href="{% static "style/opening.css" %}">
-{% endblock %}
 
 {% block title %}オープニング{% endblock %}
 


### PR DESCRIPTION
Related: #44